### PR TITLE
Use sdk-core 4.2.0-beta.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@hemilabs/smart-order-router",
-  "version": "3.26.1-beta.2",
+  "version": "3.26.1-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hemilabs/smart-order-router",
-      "version": "3.26.1",
+      "version": "3.26.1-beta.3",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",
         "@ethersproject/bignumber": "^5.0.2",
-        "@hemilabs/sdk-core": "4.2.0-beta.2",
+        "@hemilabs/sdk-core": "4.2.0-beta.5",
         "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.13.0",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -1577,9 +1577,9 @@
       }
     },
     "node_modules/@hemilabs/sdk-core": {
-      "version": "4.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@hemilabs/sdk-core/-/sdk-core-4.2.0-beta.2.tgz",
-      "integrity": "sha512-b9ZbmLxWo5gKH4SQX/mjZkNgDucaQtq3sGVuPw05pGAeejmoHSG6EEtOQElupGcswhTSb9LohPV/SnpvGy+peQ==",
+      "version": "4.2.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@hemilabs/sdk-core/-/sdk-core-4.2.0-beta.5.tgz",
+      "integrity": "sha512-R5FS4csg83QCGXdFv2vs0x1AQ+OfgaY9vPK3Dt2wqGlsaB3Rt+tori0ZjlqIEA8BVmT1lZjE+wqIqZKDVLpTzw==",
       "dependencies": {
         "@ethersproject/address": "^5.0.2",
         "@ethersproject/bignumber": "^5.7.0",
@@ -13292,9 +13292,9 @@
       }
     },
     "@hemilabs/sdk-core": {
-      "version": "4.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@hemilabs/sdk-core/-/sdk-core-4.2.0-beta.2.tgz",
-      "integrity": "sha512-b9ZbmLxWo5gKH4SQX/mjZkNgDucaQtq3sGVuPw05pGAeejmoHSG6EEtOQElupGcswhTSb9LohPV/SnpvGy+peQ==",
+      "version": "4.2.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@hemilabs/sdk-core/-/sdk-core-4.2.0-beta.5.tgz",
+      "integrity": "sha512-R5FS4csg83QCGXdFv2vs0x1AQ+OfgaY9vPK3Dt2wqGlsaB3Rt+tori0ZjlqIEA8BVmT1lZjE+wqIqZKDVLpTzw==",
       "requires": {
         "@ethersproject/address": "^5.0.2",
         "@ethersproject/bignumber": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/smart-order-router",
-  "version": "3.26.1-beta.2",
+  "version": "3.26.1-beta.3",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -37,7 +37,7 @@
     "@uniswap/default-token-list": "^11.13.0",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.9.0",
-    "@hemilabs/sdk-core": "4.2.0-beta.2",
+    "@hemilabs/sdk-core": "4.2.0-beta.5",
     "@uniswap/swap-router-contracts": "^1.3.1",
     "@uniswap/token-lists": "^1.0.0-beta.31",
     "@uniswap/universal-router": "^1.6.0",


### PR DESCRIPTION
This uses the version of sdk-core that has chainIDs restored. There are many references to said chainIDs in this package.

Related to https://github.com/hemilabs/sdk-core/pull/5