### PR TITLE
Run build before npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - run: npm ci
+      - run: npm run build
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemilabs/smart-order-router",
-  "version": "3.26.1-beta.6",
+  "version": "3.26.1-beta.7",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
This PR adds a step before npm publishing, to build the package. 

`JS-DevTools/npm-publish` defaults to ignoring "pre-scripts", they suggest running the script in a previous step in the workflow: https://github.com/JS-DevTools/npm-publish?tab=readme-ov-file#v2-behavior-changes